### PR TITLE
Add location for the calling account

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ------------
 
 * Michaël Arnauts <michael.arnauts@gmail.com>
+* Amy Nagle <kabi-git@openmuffin.com>


### PR DESCRIPTION
This adds the location of the authenticated account to the list of people returned. Part of the data was already present in the response, it's just missing the name and photo fields. To save on extra calls, this change just sets those all to "self"