### PR TITLE
try/except for charging-state and battery-level

### DIFF
--- a/locationsharinglib/locationsharinglib.py
+++ b/locationsharinglib/locationsharinglib.py
@@ -106,8 +106,14 @@ class Person:  # pylint: disable=too-many-instance-attributes
             self._accuracy = data[1][3]
             self._address = data[1][4]
             self._country_code = data[1][6]
-            self._charging = data[13][0]
-            self._battery_level = data[13][1]
+            try:
+                self._charging = data[13][0]
+            except:
+                self._charging = None
+            try:
+                self._battery_level = data[13][1]
+            except:
+                self._battery_level = None
         except (IndexError, TypeError):
             self._logger.debug(data)
             raise InvalidData


### PR DESCRIPTION
Those are not reported anymore for the account owner.

Verbatim patch as proposed by @Sarabveer in https://github.com/costastf/locationsharinglib/issues/44#issuecomment-435184520

Please consider merging this, @costastf, as the non-reporting of the account owner is screwing up my home automation system ;-) Thank you :)