### PR TITLE
try/except for charging-state and battery-level - 2nd incarnation

### DIFF
--- a/locationsharinglib/locationsharinglib.py
+++ b/locationsharinglib/locationsharinglib.py
@@ -108,11 +108,11 @@ class Person:  # pylint: disable=too-many-instance-attributes
             self._country_code = data[1][6]
             try:
                 self._charging = data[13][0]
-            except KeyError:
+            except TypeError:
                 self._charging = None
             try:
                 self._battery_level = data[13][1]
-            except KeyError:
+            except TypeError:
                 self._battery_level = None
         except (IndexError, TypeError):
             self._logger.debug(data)


### PR DESCRIPTION
Hello again!

After you merged #47 and applied e2f2cb4e6d43c32503ced98dc173089191beb72a, I was wondering why I was still not getting any information for the person that owned the account. I spent some time looking at HomeAssistant, believing that there must be another mistake there...

Unfortunately, it seems though that the `KeyError` is not the right way to go here, as it still fails.

I changed that section yet again - but this time to `TypeError`, as the error message of my testing reads:
````python
>>> self['_charging'] = data[13][0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'NoneType' object is not subscriptable
````

This seems to take care of the issue - at least it does for me... :-)