### PR TITLE
new suggestion for cookies extension in chrome

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Usage:
 **cookies.txt file**
 
 - You need to sign out, and manually sign into your Google account. Then browse to google.com/maps and extract from your "google.com" cookies and save it as `cookies.txt`
-- Checkout `this chrome extension <https://chrome.google.com/webstore/detail/get-cookiestxt/bgaddhkoddajcdgocldbbfleckgcbcid/related?hl=en>`_ to help export such file very easily
+- Checkout `this chrome extension <https://chrome.google.com/webstore/detail/open-cookiestxt/gdocmgbfkjnnpapoeobnolbbkoibbcif/related?hl=en>`_ to help export such file very easily
 - Once `cookies.txt` created, if the Google account will be signed out it **will invalidate the cookies** 
 
 


### PR DESCRIPTION
The previous one was removed from the store because it phoned home with the content of the cookies.txt file! Now suggested Open Cookies.txt (https://chrome.google.com/webstore/detail/open-cookiestxt/gdocmgbfkjnnpapoeobnolbbkoibbcif/related?hl=en)